### PR TITLE
Add script to help automate releases

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,16 @@
+#! /bin/sh
+set -ex
+
+old_version=$1
+new_version=$2
+
+version_files="lib/braze_ruby/version.rb Gemfile.lock"
+commit_message="Bumping version numbers for $new_version"
+tag_message="Tagging version $new_version"
+
+sed -i "" "s/$old_version/$new_version/g" $version_files
+git add .
+git commit --message "$commit_message"
+git push origin master
+git tag --annotate v$new_version --message "$tag_message"
+git push origin --tags


### PR DESCRIPTION
I've copy/pasted this script around to a few projects and it's been helpful to automate the process of releasing. It's not perfect and sorta annoying that you have to provide the old version but whatever. 😆 

Run like this:

```
$ ./bin/release 0.4.2 0.5.0
```

And then it takes care of the rest.