### PR TITLE
Add retry configuration pass through

### DIFF
--- a/lib/braze_ruby/deprecated.rb
+++ b/lib/braze_ruby/deprecated.rb
@@ -14,8 +14,7 @@ module BrazeRuby
 
     def schedule_message(date, message, segment_id, local_timezone = false)
       warn("[BrazeRuby] `schedule_message` is deprecated. Please use `schedule_messages` instead.")
-      schedule_messages(send_at: date, messages: message,
-        segment_id: segment_id, local_timezone: local_timezone)
+      schedule_messages(send_at: date, messages: message, segment_id: segment_id, local_timezone: local_timezone)
     end
   end
 end

--- a/lib/braze_ruby/http.rb
+++ b/lib/braze_ruby/http.rb
@@ -31,6 +31,7 @@ module BrazeRuby
         connection.headers["Authorization"] = "Bearer #{@api_key}"
 
         connection.response :logger if ENV["BRAZE_RUBY_DEBUG"]
+        connection.request :retry, @options[:retry] if @options[:retry]
 
         connection.adapter Faraday.default_adapter
 

--- a/spec/braze_ruby/http_spec.rb
+++ b/spec/braze_ruby/http_spec.rb
@@ -7,7 +7,7 @@ describe BrazeRuby::HTTP do
   describe "#connection" do
     let(:options) { double("options", "[]=": nil) }
     let(:headers) { double("headers", "[]=": nil) }
-    let(:conn) { double("conn", adapter: nil, options: options, headers: headers) }
+    let(:conn) { double("conn", adapter: nil, options: options, headers: headers, request: nil) }
     let(:api_key) { "braze-api-key" }
     let(:braze_url) { "http://example.com" }
 
@@ -27,6 +27,17 @@ describe BrazeRuby::HTTP do
       described_class.new(api_key, braze_url, {timeout: timeout}).connection
 
       expect(options).to have_received(:"[]=").with(:timeout, timeout)
+    end
+
+    it "sets the retry block if given" do
+      retry_hash = {max: 2, interval: 0.05}
+      described_class.new(api_key, braze_url, {retry: retry_hash}).connection
+      expect(conn).to have_received(:request).with(:retry, retry_hash)
+    end
+
+    it "does not set the retry block if no retry info is passed" do
+      described_class.new(api_key, braze_url).connection
+      expect(conn).not_to have_received(:request)
     end
 
     it "sets the headers" do

--- a/spec/integrations/schedule_messages_spec.rb
+++ b/spec/integrations/schedule_messages_spec.rb
@@ -8,8 +8,7 @@ describe "schedule messages" do
   let(:messages) { build(:messages) }
 
   subject(:schedule_messages) do
-    api.schedule_messages(time: test_time,
-      messages: messages, external_user_ids: user_ids)
+    api.schedule_messages(time: test_time, messages: messages, external_user_ids: user_ids)
   end
 
   context "with success", vcr: true do

--- a/spec/integrations/track_users_spec.rb
+++ b/spec/integrations/track_users_spec.rb
@@ -9,8 +9,7 @@ describe "track users" do
   let(:purchases) { [build(:purchase, time: test_time)] }
 
   subject(:track_users) do
-    api.track_users(attributes: attributes,
-      events: events, purchases: purchases)
+    api.track_users(attributes: attributes, events: events, purchases: purchases)
   end
 
   context "with success", vcr: true do


### PR DESCRIPTION
We're seeing many errors due to `Faraday::ConnectionFailed: execution expired`. Might be nice to be able to configure retries within the internal faraday client to avoid this.