### PR TITLE
Publish via GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
 version: 2.1
-
 jobs:
   test:
     parameters:
@@ -9,37 +8,15 @@ jobs:
       - image: << parameters.ruby-version >>
     steps:
       - checkout
-
       - run:
           name: Gem install bundler
           command: gem update --system && gem install bundler
-
       - run:
           name: Bundle install
           command: bundle install --jobs=4 --retry=3 --path vendor/bundle
-
       - run:
           name: Run tests
           command: bundle exec rake
-
-  publish:
-    docker:
-      - image: ruby:3.0.0
-    steps:
-      - checkout
-
-      - run:
-          name: Setup Rubygems
-          command: bash .circleci/setup-rubygems
-
-      - run:
-          name: Build gem
-          command: gem build braze_ruby.gemspec --output braze_ruby.gem
-
-      - run:
-          name: Publish gem
-          command: gem push braze_ruby.gem
-
 workflows:
   all-tests:
     jobs:
@@ -47,11 +24,3 @@ workflows:
           matrix:
             parameters:
               ruby-version: ["ruby:3.0.0", "ruby:2.7.2", "ruby:2.6.3"]
-  release:
-    jobs:
-      - publish:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,4 +23,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-version: ["ruby:3.0.0", "ruby:2.7.2", "ruby:2.6.3"]
+              ruby-version: ["ruby:3.0.1", "ruby:2.7.3", "ruby:2.6.7"]

--- a/.circleci/gem_credentials
+++ b/.circleci/gem_credentials
@@ -1,2 +1,0 @@
----
-:rubygems_api_key: REPLACE_ME

--- a/.circleci/setup-rubygems
+++ b/.circleci/setup-rubygems
@@ -1,6 +1,0 @@
-#! /bin/sh
-
-mkdir -p ~/.gem
-cp ./.circleci/gem_credentials ~/.gem/credentials
-chmod 0600 ~/.gem/credentials
-sed -i "s/REPLACE_ME/${RUBYGEMS_API_KEY}/g" ~/.gem/credentials

--- a/.github/workflows/gem_credentials
+++ b/.github/workflows/gem_credentials
@@ -1,0 +1,2 @@
+---
+:rubygems_api_key: REPLACE_ME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: release
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup rubygems
+        run: |
+          mkdir ~/.gem
+          cp ./.github/workflows/gem_credentials ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          sed -i "s/REPLACE_ME/${{ secrets.RUBYGEMS_KEY }}/g" ~/.gem/credentials
+      - name: Build gem
+        run: gem build braze_ruby.gemspec --output braze_ruby.gem
+      - name: Publish gem
+        run: gem push braze_ruby.gem

--- a/lib/braze_ruby/deprecated.rb
+++ b/lib/braze_ruby/deprecated.rb
@@ -15,7 +15,7 @@ module BrazeRuby
     def schedule_message(date, message, segment_id, local_timezone = false)
       warn("[BrazeRuby] `schedule_message` is deprecated. Please use `schedule_messages` instead.")
       schedule_messages(send_at: date, messages: message,
-                        segment_id: segment_id, local_timezone: local_timezone)
+        segment_id: segment_id, local_timezone: local_timezone)
     end
   end
 end

--- a/spec/integrations/schedule_messages_spec.rb
+++ b/spec/integrations/schedule_messages_spec.rb
@@ -9,7 +9,7 @@ describe "schedule messages" do
 
   subject(:schedule_messages) do
     api.schedule_messages(time: test_time,
-                          messages: messages, external_user_ids: user_ids)
+      messages: messages, external_user_ids: user_ids)
   end
 
   context "with success", vcr: true do

--- a/spec/integrations/track_users_spec.rb
+++ b/spec/integrations/track_users_spec.rb
@@ -10,7 +10,7 @@ describe "track users" do
 
   subject(:track_users) do
     api.track_users(attributes: attributes,
-                    events: events, purchases: purchases)
+      events: events, purchases: purchases)
   end
 
   context "with success", vcr: true do


### PR DESCRIPTION
This PR aims to update the publishing strategy for the gem. I was previously publishing when tags were pushed via CircleCI but that has the drawback of not wanting to build forked PRs. So my new strategy is to separate testing a PR from publishing the gem by migrating to GitHub actions for publishing.

Closes #35