### PR TITLE
Allow options when exporting users by ids

### DIFF
--- a/lib/braze_ruby/rest/export_users.rb
+++ b/lib/braze_ruby/rest/export_users.rb
@@ -4,17 +4,17 @@ module BrazeRuby
   module REST
     class ExportUsers < Base
       def perform(external_ids: nil, segment_id: nil, **options)
-        return export_users_by_ids(external_ids) if external_ids
+        return export_users_by_ids(external_ids, options) if external_ids
 
         export_users_by_segment(segment_id, options) if segment_id
       end
 
       private
 
-      def export_users_by_ids(external_ids)
+      def export_users_by_ids(external_ids, options)
         http.post "/users/export/ids", {
           external_ids: external_ids
-        }
+        }.merge(options)
       end
 
       def export_users_by_segment(segment_id, options)

--- a/spec/braze_ruby/rest/export_users_spec.rb
+++ b/spec/braze_ruby/rest/export_users_spec.rb
@@ -5,44 +5,47 @@ require "spec_helper"
 describe BrazeRuby::REST::ExportUsers do
   let(:http) { double(:http) }
 
+  let(:external_ids) { nil }
+  let(:segment_id) { nil }
+  let(:options) { {} }
+
   context "with external ids" do
-    let(:payload) { {external_ids: [1]} }
+    let(:external_ids) { [1] }
 
     it "makes an api call to the users export by id endpoint" do
-      expect(http).to receive(:post).with("/users/export/ids", payload)
+      expect(http).to receive(:post).with("/users/export/ids", external_ids: external_ids)
 
       export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
       export_users.http = http
-      export_users.perform(**payload)
+      export_users.perform(external_ids: external_ids, segment_id: segment_id, **options)
     end
   end
 
   context "with a segment id" do
-    let(:payload) { {segment_id: 1} }
+    let(:segment_id) { 1 }
 
     it "makes an api call to the users export by segment endpoint" do
-      expect(http).to receive(:post).with("/users/export/segment", payload)
+      expect(http).to receive(:post).with("/users/export/segment", segment_id: 1)
 
       export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
       export_users.http = http
-      export_users.perform(**payload)
+      export_users.perform(external_ids: external_ids, segment_id: segment_id, **options)
     end
   end
 
   context "without any ids" do
-    let(:payload) { {} }
-
     it "does not make an api call" do
       expect(http).to_not receive(:post)
 
       export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
       export_users.http = http
-      export_users.perform(**payload)
+      export_users.perform(external_ids: external_ids, segment_id: segment_id, **options)
     end
   end
 
   context "with both types of ids" do
-    let(:payload) { {external_ids: [1], segment_id: 1} }
+    let(:external_ids) { [1] }
+    let(:segment_id) { 1 }
 
     it "prefers the export by id endpoint and ignores the segment id" do
       expect(http).to receive(:post).with("/users/export/ids", {external_ids: [1]})
@@ -50,7 +53,7 @@ describe BrazeRuby::REST::ExportUsers do
 
       export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
       export_users.http = http
-      export_users.perform(**payload)
+      export_users.perform(external_ids: external_ids, segment_id: segment_id, **options)
     end
   end
 end

--- a/spec/braze_ruby/rest/export_users_spec.rb
+++ b/spec/braze_ruby/rest/export_users_spec.rb
@@ -31,6 +31,18 @@ describe BrazeRuby::REST::ExportUsers do
       export_users.http = http
       export_users.perform(external_ids: external_ids, segment_id: segment_id, **options)
     end
+
+    context "with options" do
+      let(:options) { {foo: "bar"} }
+
+      it "sends those options to the endpoint" do
+        expect(http).to receive(:post).with("/users/export/segment", segment_id: 1, foo: "bar")
+
+        export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
+        export_users.http = http
+        export_users.perform(external_ids: external_ids, segment_id: segment_id, **options)
+      end
+    end
   end
 
   context "without any ids" do

--- a/spec/braze_ruby/rest/export_users_spec.rb
+++ b/spec/braze_ruby/rest/export_users_spec.rb
@@ -5,17 +5,52 @@ require "spec_helper"
 describe BrazeRuby::REST::ExportUsers do
   let(:http) { double(:http) }
 
-  let(:payload) { {external_ids: external_ids} }
-  let(:external_ids) { [1] }
+  context "with external ids" do
+    let(:payload) { {external_ids: [1]} }
 
-  subject { described_class.new :api_key, :rest_url, {} }
+    it "makes an api call to the users export by id endpoint" do
+      expect(http).to receive(:post).with("/users/export/ids", payload)
 
-  before { subject.http = http }
+      export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
+      export_users.http = http
+      export_users.perform(**payload)
+    end
+  end
 
-  it "makes an http call to the track user endpoint" do
-    expect(http).to receive(:post).with "/users/export/ids",
-      payload
+  context "with a segment id" do
+    let(:payload) { {segment_id: 1} }
 
-    subject.perform(**payload)
+    it "makes an api call to the users export by segment endpoint" do
+      expect(http).to receive(:post).with("/users/export/segment", payload)
+
+      export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
+      export_users.http = http
+      export_users.perform(**payload)
+    end
+  end
+
+  context "without any ids" do
+    let(:payload) { {} }
+
+    it "does not make an api call" do
+      expect(http).to_not receive(:post)
+
+      export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
+      export_users.http = http
+      export_users.perform(**payload)
+    end
+  end
+
+  context "with both types of ids" do
+    let(:payload) { {external_ids: [1], segment_id: 1} }
+
+    it "prefers the export by id endpoint and ignores the segment id" do
+      expect(http).to receive(:post).with("/users/export/ids", {external_ids: [1]})
+      expect(http).to_not receive(:post).with("/users/export/segment", anything)
+
+      export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
+      export_users.http = http
+      export_users.perform(**payload)
+    end
   end
 end

--- a/spec/braze_ruby/rest/export_users_spec.rb
+++ b/spec/braze_ruby/rest/export_users_spec.rb
@@ -19,6 +19,18 @@ describe BrazeRuby::REST::ExportUsers do
       export_users.http = http
       export_users.perform(external_ids: external_ids, segment_id: segment_id, **options)
     end
+
+    context "with options" do
+      let(:options) { {foo: "bar"} }
+
+      it "sends those options to the endpoint" do
+        expect(http).to receive(:post).with("/users/export/ids", external_ids: [1], foo: "bar")
+
+        export_users = BrazeRuby::REST::ExportUsers.new(:api_key, :rest_url, {})
+        export_users.http = http
+        export_users.perform(external_ids: external_ids, segment_id: segment_id, **options)
+      end
+    end
   end
 
   context "with a segment id" do


### PR DESCRIPTION
I was going to do some user exporting and wanted to specify the fields to return based on the docs here:

https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/#request-parameters

But then I noticed that `options` weren't being passed down to the actual api call. So all this PR does is merge them in like we do on the segment version of this call.

I went to add this behavior and wanted to update the specs. I started off by rewriting the spec file using `context` to cover the various ways we could be exporting. Then I modernized a bit and covered the existing options merging so that I could add my new behavior in the final commit.