### PR TITLE
Add support for campaign ids in scheduled messages

### DIFF
--- a/lib/braze_ruby/rest/schedule_messages.rb
+++ b/lib/braze_ruby/rest/schedule_messages.rb
@@ -3,19 +3,21 @@
 module BrazeRuby
   module REST
     class ScheduleMessages < Base
-      attr_reader :time, :messages, :in_local_time, :external_user_ids
+      attr_reader :time, :messages, :in_local_time, :external_user_ids, :campaign_id
 
-      def initialize(api_key, braze_url, options, time: nil, messages: [], external_user_ids: [], in_local_time: false)
+      def initialize(api_key, braze_url, options, time: nil, messages: [], external_user_ids: [], in_local_time: false, campaign_id: nil)
         @messages = messages
         @time = time
         @external_user_ids = external_user_ids
         @in_local_time = in_local_time
+        @campaign_id = campaign_id
         super api_key, braze_url, options
       end
 
       def perform
         http.post "/messages/schedule/create", {
           external_user_ids: external_user_ids,
+          campaign_id: campaign_id,
           schedule: {
             time: time,
             in_local_time: in_local_time

--- a/spec/braze_ruby/rest/schedule_messages_spec.rb
+++ b/spec/braze_ruby/rest/schedule_messages_spec.rb
@@ -9,6 +9,7 @@ describe BrazeRuby::REST::ScheduleMessages do
     {
       external_user_ids: :external_user_ids,
       time: :time,
+      campaign_id: :campaign_id,
       in_local_time: :in_local_time,
       messages: :messages
     }
@@ -29,6 +30,7 @@ describe BrazeRuby::REST::ScheduleMessages do
   def expect_schedule_messages_http_call
     expect(http).to receive(:post).with "/messages/schedule/create", {
       external_user_ids: :external_user_ids,
+      campaign_id: :campaign_id,
       schedule: {
         time: :time,
         in_local_time: :in_local_time


### PR DESCRIPTION
This change allows developers to pass in a `campaign_id` parameter when scheduling messages.