### PR TITLE
Fix missing configuration reference in API initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ end
 
 ```ruby
 api = BrazeRuby::API.new('<braze-rest-api-key>', '<braze-rest-url')
+
+# Alternatively, if configuration is set via `BrazeRuby.configure`
+
+api = BrazeRuby::API.new()
 ```
 
 ### Track User Attributes

--- a/lib/braze_ruby/api.rb
+++ b/lib/braze_ruby/api.rb
@@ -43,10 +43,13 @@ module BrazeRuby
 
     attr_reader :api_key, :braze_url, :options
 
-    def initialize(api_key = nil, braze_url = nil, options = nil)
-      @api_key = api_key || configuration.rest_api_key
-      @braze_url = braze_url || configuration.rest_url
+    def initialize(rest_api_key = nil, rest_url = nil, options = nil)
+      @api_key = rest_api_key || configuration.rest_api_key
+      @braze_url = rest_url || configuration.rest_url
       @options = options || configuration.options || {}
+
+      raise ArgumentError, "BrazeRuby.configure rest_api_key is missing" if @api_key.nil? || @api_key.empty?
+      raise ArgumentError, "BrazeRuby.configure rest_url is missing"  if @braze_url.nil? || @braze_url.empty?
     end
 
     private

--- a/lib/braze_ruby/api.rb
+++ b/lib/braze_ruby/api.rb
@@ -43,10 +43,16 @@ module BrazeRuby
 
     attr_reader :api_key, :braze_url, :options
 
-    def initialize(api_key, braze_url, options = {})
+    def initialize(api_key = nil, braze_url = nil, options = nil)
       @api_key = api_key || configuration.rest_api_key
       @braze_url = braze_url || configuration.rest_url
-      @options = options || configuration.options
+      @options = options || configuration.options || {}
+    end
+
+    private
+
+    def configuration
+      BrazeRuby.configuration
     end
   end
 end

--- a/spec/braze_ruby/api_spec.rb
+++ b/spec/braze_ruby/api_spec.rb
@@ -3,4 +3,18 @@
 require "spec_helper"
 
 describe BrazeRuby::API do
+    it "can be initialized with Rails style configuration" do
+        # configuration is already set by spec_helper
+        expect{BrazeRuby::API.new}.to_not raise_error
+    end
+
+    it "initialization raises argument error when missing configuration" do
+        # override configuration from spec_helper
+        BrazeRuby.configure do |config|
+            config.rest_api_key = nil
+            config.rest_url = nil
+        end
+
+        expect{BrazeRuby::API.new}.to raise_error(ArgumentError)
+    end
 end


### PR DESCRIPTION
This change fixes using this library with the configuration initializer pattern documented in the configuration