### PR TITLE
Allows implicit BrazeRuby::API instanciation based on config

### DIFF
--- a/lib/braze_ruby/api.rb
+++ b/lib/braze_ruby/api.rb
@@ -51,10 +51,10 @@ module BrazeRuby
       end
     end
 
-    def initialize_with_hash(options = {})
-      @api_key = options[:api_key] || BrazeRuby.configuration.rest_api_key
-      @braze_url = options[:braze_url] || BrazeRuby.configuration.rest_url
-      @options = options[:options] || BrazeRuby.configuration.options
+    def initialize_with_hash(config = {})
+      @api_key = config[:api_key] || BrazeRuby.configuration.rest_api_key
+      @braze_url = config[:braze_url] || BrazeRuby.configuration.rest_url
+      @options = config[:options] || BrazeRuby.configuration.options
     end
 
     def initialize_with_args(api_key, braze_url, options = {})

--- a/lib/braze_ruby/api.rb
+++ b/lib/braze_ruby/api.rb
@@ -43,10 +43,24 @@ module BrazeRuby
 
     attr_reader :api_key, :braze_url, :options
 
-    def initialize(api_key, braze_url, options = {})
-      @api_key = api_key || configuration.rest_api_key
-      @braze_url = braze_url || configuration.rest_url
-      @options = options || configuration.options
+    def initialize(*args)
+      if args.length <= 1
+        initialize_with_hash(args.first || {})
+      else
+        initialize_with_args(*args)
+      end
+    end
+
+    def initialize_with_hash(options = {})
+      @api_key = options[:api_key] || BrazeRuby.configuration.rest_api_key
+      @braze_url = options[:braze_url] || BrazeRuby.configuration.rest_url
+      @options = options[:options] || BrazeRuby.configuration.options
+    end
+
+    def initialize_with_args(api_key, braze_url, options = {})
+      @api_key = api_key || BrazeRuby.configuration.rest_api_key
+      @braze_url = braze_url || BrazeRuby.configuration.rest_url
+      @options = options || BrazeRuby.configuration.options
     end
   end
 end

--- a/spec/braze_ruby/api_spec.rb
+++ b/spec/braze_ruby/api_spec.rb
@@ -5,8 +5,7 @@ require "spec_helper"
 describe BrazeRuby::API do
   let(:rest_api_key) { SecureRandom.uuid }
   let(:rest_url) { "https://braze.example.com" }
-  let(:options) { { option: "value" } }
-
+  let(:options) { {option: "value"} }
 
   context "takes into account config options for implicit instanciation" do
     subject(:api) { BrazeRuby::API.new }
@@ -19,32 +18,32 @@ describe BrazeRuby::API do
       end
     end
 
-    it 'braze_url' do
+    it "braze_url" do
       expect(api.braze_url).to eq(rest_url)
     end
 
-    it 'api_key' do
+    it "api_key" do
       expect(api.api_key).to eq(rest_api_key)
     end
 
-    it 'options' do
-      expect(api.options).to eq({ option: "value" })
+    it "options" do
+      expect(api.options).to eq({option: "value"})
     end
   end
 
   context "supports explicit instanciation" do
     subject(:api) { BrazeRuby::API.new(rest_api_key, rest_url, options) }
 
-    it 'braze_url' do
+    it "braze_url" do
       expect(api.braze_url).to eq(rest_url)
     end
 
-    it 'api_key' do
+    it "api_key" do
       expect(api.api_key).to eq(rest_api_key)
     end
 
-    it 'options' do
-      expect(api.options).to eq({ option: "value" })
+    it "options" do
+      expect(api.options).to eq({option: "value"})
     end
   end
 end

--- a/spec/braze_ruby/api_spec.rb
+++ b/spec/braze_ruby/api_spec.rb
@@ -3,4 +3,48 @@
 require "spec_helper"
 
 describe BrazeRuby::API do
+  let(:rest_api_key) { SecureRandom.uuid }
+  let(:rest_url) { "https://braze.example.com" }
+  let(:options) { { option: "value" } }
+
+
+  context "takes into account config options for implicit instanciation" do
+    subject(:api) { BrazeRuby::API.new }
+
+    before do
+      BrazeRuby.configure do |config|
+        config.rest_api_key = rest_api_key
+        config.rest_url = rest_url
+        config.options = options
+      end
+    end
+
+    it 'braze_url' do
+      expect(api.braze_url).to eq(rest_url)
+    end
+
+    it 'api_key' do
+      expect(api.api_key).to eq(rest_api_key)
+    end
+
+    it 'options' do
+      expect(api.options).to eq({ option: "value" })
+    end
+  end
+
+  context "supports explicit instanciation" do
+    subject(:api) { BrazeRuby::API.new(rest_api_key, rest_url, options) }
+
+    it 'braze_url' do
+      expect(api.braze_url).to eq(rest_url)
+    end
+
+    it 'api_key' do
+      expect(api.api_key).to eq(rest_api_key)
+    end
+
+    it 'options' do
+      expect(api.options).to eq({ option: "value" })
+    end
+  end
 end


### PR DESCRIPTION
## 🔍 Context

Hello! Had the pleasure to stumble upon this gem when i had to implement `unsunscribes` Braze endpoint and the official gem is not supporting it.
While doing my POC i tried to use configuration as instructed in the README but the `BrazeRuby::API.new` calls would fail because of `ArgumentError: wrong number of arguments (given 0, expected 2..3)`. I tried to force it via a `BrazeRuby::API.new(nil, nil)` but it's far from satisfying.

I find the configuration block to be a good design since it allows for applications to separate implementation and configuration files.

I tried to wrap up a quick spec and implementation of what i think it could look like as a proposal. I would love to contribute to the gem and move forward with this PR if you think it could make a good addition.

Have a nice day!