### PR TITLE
Add console script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 ### Added
 
 * Add a CHANGELOG ([#61][])
+* Add console script ([#63][])
 
 ### Changed
 
@@ -108,3 +109,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#47]: https://github.com/jonallured/braze_ruby/pull/47
 [#61]: https://github.com/jonallured/braze_ruby/pull/61
 [#62]: https://github.com/jonallured/braze_ruby/pull/62
+[#63]: https://github.com/jonallured/braze_ruby/pull/63

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "braze_ruby"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "irb"
+IRB.start(__FILE__)


### PR DESCRIPTION
When you create a new gem these days one thing the skeleton comes with is a lil `./bin/console` executable you can run to interact with the code you are working on. This PR just adds something like this here.