### PR TITLE
Improve configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog][] and this project adheres to
 
 ### Changed
 
+* Improve configuration support ([#64][])
+
 ### Deprecated
 
 ### Removed
@@ -110,3 +112,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#61]: https://github.com/jonallured/braze_ruby/pull/61
 [#62]: https://github.com/jonallured/braze_ruby/pull/62
 [#63]: https://github.com/jonallured/braze_ruby/pull/63
+[#64]: https://github.com/jonallured/braze_ruby/pull/64

--- a/README.md
+++ b/README.md
@@ -19,22 +19,43 @@ Or install it yourself as:
 
 ### Configuration
 
-Configuration options may be passed when a new API object is instantiated:
+Configuration settings may be passed when a new API object is instantiated:
 
 ```ruby
-BrazeRuby::API.new('<braze-rest-api-key>', '<braze-rest-url', {<additional options>})
+api_key = "instance-api-key"
+braze_url = "instance-braze-url"
+options = { key: "instance-options" }
+
+api = BrazeRuby::API.new(api_key, braze_url, options)
+
+api.api_key
+# => "instance-api-key"
+api.braze_url
+# => "instance-braze-url"
+api.options
+# => {:key=>"instance-options"}
 ```
 
 Alternatively, you can pass your [Braze REST API key][braze_api_key], [Braze
 REST URL][braze_url], and any required [Faraday options][faraday_options] to the
-`BrazeRuby::configure` method:
+`BrazeRuby::configure` method. Then, if you instantiate an API object with no
+arguments it will use these global configuration settings:
 
 ```ruby
 BrazeRuby.configure do |config|
-  config.rest_api_key = '<braze-rest-api-key>'
-  config.rest_url = '<braze-rest-url>'
-  config.options = {<additional options>}
+  config.rest_api_key = "global-api-key"
+  config.rest_url = "global-braze-url"
+  config.options = { key: "global-options" }
 end
+
+api = BrazeRuby::API.new
+
+api.api_key
+# => "global-api-key"
+api.braze_url
+# => "global-braze-url"
+api.options
+# => {:key=>"global-options"}
 ```
 
 ## Examples

--- a/lib/braze_ruby.rb
+++ b/lib/braze_ruby.rb
@@ -16,6 +16,10 @@ module BrazeRuby
     @configuration ||= Configuration.new
   end
 
+  def self.reset
+    @configuration = Configuration.new
+  end
+
   def self.configure
     yield(configuration)
   end

--- a/lib/braze_ruby/api.rb
+++ b/lib/braze_ruby/api.rb
@@ -43,10 +43,10 @@ module BrazeRuby
 
     attr_reader :api_key, :braze_url, :options
 
-    def initialize(api_key, braze_url, options = {})
-      @api_key = api_key || configuration.rest_api_key
-      @braze_url = braze_url || configuration.rest_url
-      @options = options || configuration.options
+    def initialize(api_key = nil, braze_url = nil, options = nil)
+      @api_key = api_key || BrazeRuby.configuration.rest_api_key
+      @braze_url = braze_url || BrazeRuby.configuration.rest_url
+      @options = options || BrazeRuby.configuration.options || {}
     end
   end
 end

--- a/spec/braze_ruby/api_spec.rb
+++ b/spec/braze_ruby/api_spec.rb
@@ -3,4 +3,69 @@
 require "spec_helper"
 
 describe BrazeRuby::API do
+  describe "#new" do
+    before do
+      BrazeRuby.reset
+    end
+
+    context "with no configuration settings" do
+      it "has nil for configuration settings" do
+        api = BrazeRuby::API.new
+
+        expect(api.api_key).to eq nil
+        expect(api.braze_url).to eq nil
+        expect(api.options).to eq({})
+      end
+    end
+
+    context "with instance configuration settings" do
+      it "has those instance configuration settings" do
+        api = BrazeRuby::API.new(
+          "instance-api-key",
+          "instance-braze-url",
+          {key: "instance-options"}
+        )
+
+        expect(api.api_key).to eq "instance-api-key"
+        expect(api.braze_url).to eq "instance-braze-url"
+        expect(api.options).to eq({key: "instance-options"})
+      end
+    end
+
+    context "with global configuration settings" do
+      it "has those global configuration settings" do
+        BrazeRuby.configure do |config|
+          config.rest_api_key = "global-api-key"
+          config.rest_url = "global-braze-url"
+          config.options = {key: "global-options"}
+        end
+
+        api = BrazeRuby::API.new
+
+        expect(api.api_key).to eq "global-api-key"
+        expect(api.braze_url).to eq "global-braze-url"
+        expect(api.options).to eq({key: "global-options"})
+      end
+    end
+
+    context "with instance and global configuration settings" do
+      it "ignores the global settings and prefers the instance settings" do
+        BrazeRuby.configure do |config|
+          config.rest_api_key = "global-api-key"
+          config.rest_url = "global-braze-url"
+          config.options = {key: "global-options"}
+        end
+
+        api = BrazeRuby::API.new(
+          "instance-api-key",
+          "instance-braze-url",
+          {key: "instance-options"}
+        )
+
+        expect(api.api_key).to eq "instance-api-key"
+        expect(api.braze_url).to eq "instance-braze-url"
+        expect(api.options).to eq({key: "instance-options"})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is heavily inspired by #51 and #59 to arrive at something I think both PR authors would like. The ultimate goal is to provide better support for configuring the gem in whichever way is more desired. I updated the README to illustrate how either instance-level configuration settings could be used or global ones instead. Then I updated the `BrazeRuby::API.new` method signature to not require any arguments.

From there I blended those PR approaches to arrive at a simple solution:

* prefer instance level settings
* use global settings when instance settings are not provided
* finally fallback options to an empty hash

Then I added specs which caused me to have to add a `BrazeRuby.reset` method so that test state did not leak between runs.

That's it! Thanks so much to @gerbal and @hugolepetit for their ideas that lead me here and sorry it took literal years. 😬 