### PR TITLE
Improve release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,15 @@
 name: release
+
 on:
   push:
     tags:
       - v*
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup rubygems
         run: |
           mkdir ~/.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 ### Changed
 
 * Improve configuration support ([#64][])
+* Improve release script ([#65][])
 
 ### Deprecated
 
@@ -113,3 +114,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#62]: https://github.com/jonallured/braze_ruby/pull/62
 [#63]: https://github.com/jonallured/braze_ruby/pull/63
 [#64]: https://github.com/jonallured/braze_ruby/pull/64
+[#65]: https://github.com/jonallured/braze_ruby/pull/65

--- a/README.md
+++ b/README.md
@@ -328,6 +328,16 @@ export BRAZE_RUBY_DEBUG=true
 bundle exec rails whatever
 ```
 
+## Releasing
+
+New versions are released by running a script locally that bumps the patch level
+of the gem and then pushes to a GitHub Action that actually sends the new
+version to RubyGems.org:
+
+```
+$ ./bin/release
+```
+
 ## Contributing
 
 1. Fork it

--- a/bin/release
+++ b/bin/release
@@ -1,16 +1,6 @@
 #! /bin/sh
 set -ex
 
-old_version=$1
-new_version=$2
-
-version_files="lib/braze_ruby/version.rb Gemfile.lock"
-commit_message="Bumping version numbers for $new_version"
-tag_message="Tagging version $new_version"
-
-sed -i "" "s/$old_version/$new_version/g" $version_files
-git add .
-git commit --message "$commit_message"
+bundle exec bump patch --tag
 git push origin main
-git tag --annotate v$new_version --message "$tag_message"
 git push origin --tags

--- a/braze_ruby.gemspec
+++ b/braze_ruby.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
 
+  spec.add_development_dependency "bump"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
This PR improves the release script by using the [bump](https://github.com/gregorym/bump) gem and also includes some details in the README so Future Jon can remember how this works!! 😅 Once this is merged then I can actually run this script and that should publish 0.9.0 with the config changes that I'm keen to get out.