### PR TITLE
Faraday middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog][] and this project adheres to
 
 ### Added
 
+* Support for Faraday middlewares ([#66][])
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ REST URL][braze_url], and any required [Faraday options][faraday_options] to the
 `BrazeRuby::configure` method. Then, if you instantiate an API object with no
 arguments it will use these global configuration settings:
 
+
 ```ruby
 BrazeRuby.configure do |config|
   config.rest_api_key = "global-api-key"
@@ -57,6 +58,13 @@ api.braze_url
 api.options
 # => {:key=>"global-options"}
 ```
+
+#### Available `options` keys
+
+- retry - Number of times to retry a failed request
+- open_timeout - Number of seconds to wait for the connection to open
+- timeout - Number of seconds to wait for the request to complete
+- middlewares - Array of Faraday middleware to use
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ REST URL][braze_url], and any required [Faraday options][faraday_options] to the
 `BrazeRuby::configure` method. Then, if you instantiate an API object with no
 arguments it will use these global configuration settings:
 
-
 ```ruby
 BrazeRuby.configure do |config|
   config.rest_api_key = "global-api-key"

--- a/lib/braze_ruby/http.rb
+++ b/lib/braze_ruby/http.rb
@@ -50,6 +50,10 @@ module BrazeRuby
 
         connection.options[:timeout] = @options[:timeout]
         connection.options[:open_timeout] = @options[:open_timeout]
+
+        @options.fetch(:middlewares, []).each do |middleware|
+          connection.use middleware
+        end
       end
     end
 

--- a/spec/braze_ruby/http_spec.rb
+++ b/spec/braze_ruby/http_spec.rb
@@ -7,7 +7,7 @@ describe BrazeRuby::HTTP do
   describe "#connection" do
     let(:options) { double("options", "[]=": nil) }
     let(:headers) { double("headers", "[]=": nil) }
-    let(:conn) { double("conn", adapter: nil, options: options, headers: headers, request: nil) }
+    let(:conn) { double("conn", adapter: nil, options: options, headers: headers, request: nil, use: nil) }
     let(:api_key) { "braze-api-key" }
     let(:braze_url) { "http://example.com" }
 
@@ -66,6 +66,12 @@ describe BrazeRuby::HTTP do
       described_class.new(api_key, braze_url).connection
 
       expect(conn).to have_received(:adapter).with(:default_adapter)
+    end
+
+    it "enables Faraday middlewares" do
+      described_class.new(api_key, braze_url, middlewares: [Faraday::Response::RaiseError]).connection
+
+      expect(conn).to have_received(:use).with(Faraday::Response::RaiseError)
     end
   end
 end


### PR DESCRIPTION
Make Faraday middlewares available in the option hash to allow desired behavior, e.g. for instrumentation or raising errors when the API call failed.
