### PR TITLE
Use more generic CI job names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+
 jobs:
   test:
     parameters:
@@ -17,10 +18,16 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec rake
+
 workflows:
   all-tests:
     jobs:
       - test:
-          matrix:
-            parameters:
-              ruby-version: ["ruby:3.1.6", "ruby:3.2.5", "ruby:3.3.5"]
+          name: test-latest
+          ruby-version: ruby:3.3.5
+      - test:
+          name: test-minus-one
+          ruby-version: ruby:3.2.5
+      - test:
+          name: test-minus-two
+          ruby-version: ruby:3.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ The format is based on [Keep a Changelog][] and this project adheres to
 ## [Unreleased][]
 
 ### Added
+
 * Partial support for Braze catalogs ([#60][])
 
 ### Changed
+
+* Use more generic CI job names ([#67][])
 
 ### Deprecated
 
@@ -126,3 +129,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#63]: https://github.com/jonallured/braze_ruby/pull/63
 [#64]: https://github.com/jonallured/braze_ruby/pull/64
 [#65]: https://github.com/jonallured/braze_ruby/pull/65
+[#67]: https://github.com/jonallured/braze_ruby/pull/67


### PR DESCRIPTION
This project is configured to require CI jobs before merging - that looks like this:

![Screenshot 2024-11-15 at 8 54 37 AM](https://github.com/user-attachments/assets/4a1e3a54-47b9-4222-9c33-b17c37483ef5)

But the problem is that every time a new Ruby version is released then the automatically create job name on CircleCI includes that version number and I have to go in and adjust this configuration.

What this PR does is use more generic names for these jobs so that I can update the version number but the name doesn't change:

* test-ruby:3.3.5 => test-latest
* test-ruby:3.2.5 => test-minus-one
* test-ruby:3.1.6 => test-minus-two

So whatever the latest Ruby is will be tested by the `test-latest` job. Whatever is the latest minus one Ruby will be tested by the `test-minus-one` job and same for minus two.