### PR TITLE
Bump Ruby versions on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,10 @@ workflows:
     jobs:
       - test:
           name: test-latest
-          ruby-version: ruby:3.3.5
+          ruby-version: ruby:3.3.6
       - test:
           name: test-minus-one
-          ruby-version: ruby:3.2.5
+          ruby-version: ruby:3.2.6
       - test:
           name: test-minus-two
           ruby-version: ruby:3.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 ### Changed
 
 * Use more generic CI job names ([#67][])
+* Bump Ruby versions for CI ([#68][])
 
 ### Deprecated
 
@@ -130,3 +131,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#64]: https://github.com/jonallured/braze_ruby/pull/64
 [#65]: https://github.com/jonallured/braze_ruby/pull/65
 [#67]: https://github.com/jonallured/braze_ruby/pull/67
+[#68]: https://github.com/jonallured/braze_ruby/pull/68


### PR DESCRIPTION
Hot on the heels of #67 this PR bumps the patch level versions of two Rubies. That's all that's the PR.