### PR TITLE
Support emails_to_identify and phone_numbers_to_identify in identify_users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog][] and this project adheres to
 
 ### Added
 
+* Support `emails_to_identify` and `phone_numbers_to_identify` in `identify_users`
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -309,6 +309,30 @@ api.identify_users(
 )
 ```
 
+#### Identify a user by email
+
+```ruby
+api.identify_users(
+  emails_to_identify: [{
+    external_id: 1234,
+    email: "user@example.com",
+    prioritization: ["unidentified", "most_recently_updated"]
+  }]
+)
+```
+
+#### Identify a user by phone number
+
+```ruby
+api.identify_users(
+  phone_numbers_to_identify: [{
+    external_id: 1234,
+    phone: "+15555555555",
+    prioritization: ["unidentified", "most_recently_updated"]
+  }]
+)
+```
+
 ### External ID Migration
 
 #### Rename users' external IDs with an array of external_id_renames

--- a/lib/braze_ruby/rest/identify_users.rb
+++ b/lib/braze_ruby/rest/identify_users.rb
@@ -3,10 +3,12 @@
 module BrazeRuby
   module REST
     class IdentifyUsers < Base
-      def perform(aliases_to_identify: [])
-        http.post "/users/identify", {
-          aliases_to_identify: aliases_to_identify
-        }
+      def perform(aliases_to_identify: [], emails_to_identify: [], phone_numbers_to_identify: [])
+        payload = {}
+        payload[:aliases_to_identify] = aliases_to_identify if aliases_to_identify.any?
+        payload[:emails_to_identify] = emails_to_identify if emails_to_identify.any?
+        payload[:phone_numbers_to_identify] = phone_numbers_to_identify if phone_numbers_to_identify.any?
+        http.post "/users/identify", payload
       end
     end
   end

--- a/spec/braze_ruby/rest/identify_users_spec.rb
+++ b/spec/braze_ruby/rest/identify_users_spec.rb
@@ -5,22 +5,97 @@ require "spec_helper"
 describe BrazeRuby::REST::IdentifyUsers do
   let(:http) { double(:http) }
 
-  let(:payload) { {aliases_to_identify: [user]} }
-
-  let(:user) do
-    {
-      external_id: 123,
-      user_alias: {alias_name: "abc", alias_label: "foo"}
-    }
-  end
-
   subject { described_class.new :api_key, :rest_url, {} }
 
   before { subject.http = http }
 
-  it "makes an http call to the identify users endpoint" do
-    expect(http).to receive(:post).with "/users/identify", payload
+  context "with aliases_to_identify" do
+    let(:user) do
+      {
+        external_id: 123,
+        user_alias: {alias_name: "abc", alias_label: "foo"}
+      }
+    end
 
-    subject.perform(**payload)
+    it "posts aliases to the identify users endpoint" do
+      expect(http).to receive(:post).with "/users/identify", {
+        aliases_to_identify: [user]
+      }
+
+      subject.perform(aliases_to_identify: [user])
+    end
+  end
+
+  context "with emails_to_identify" do
+    let(:user) do
+      {
+        external_id: 123,
+        email: "user@example.com",
+        prioritization: %w[unidentified most_recently_updated]
+      }
+    end
+
+    it "posts emails to the identify users endpoint" do
+      expect(http).to receive(:post).with "/users/identify", {
+        emails_to_identify: [user]
+      }
+
+      subject.perform(emails_to_identify: [user])
+    end
+  end
+
+  context "with phone_numbers_to_identify" do
+    let(:user) do
+      {
+        external_id: 123,
+        phone: "+15555555555",
+        prioritization: %w[unidentified most_recently_updated]
+      }
+    end
+
+    it "posts phone numbers to the identify users endpoint" do
+      expect(http).to receive(:post).with "/users/identify", {
+        phone_numbers_to_identify: [user]
+      }
+
+      subject.perform(phone_numbers_to_identify: [user])
+    end
+  end
+
+  context "with multiple identifier types" do
+    let(:alias_user) do
+      {
+        external_id: 123,
+        user_alias: {alias_name: "abc", alias_label: "foo"}
+      }
+    end
+
+    let(:email_user) do
+      {
+        external_id: 456,
+        email: "user@example.com",
+        prioritization: %w[unidentified most_recently_updated]
+      }
+    end
+
+    it "includes all provided identifier types in the payload" do
+      expect(http).to receive(:post).with "/users/identify", {
+        aliases_to_identify: [alias_user],
+        emails_to_identify: [email_user]
+      }
+
+      subject.perform(
+        aliases_to_identify: [alias_user],
+        emails_to_identify: [email_user]
+      )
+    end
+  end
+
+  context "with no arguments" do
+    it "posts an empty payload" do
+      expect(http).to receive(:post).with "/users/identify", {}
+
+      subject.perform
+    end
   end
 end


### PR DESCRIPTION
## Summary

The Braze [`/users/identify`](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/) endpoint accepts three identifier types:

- `aliases_to_identify` — identify by user alias
- `emails_to_identify` — identify by email address (requires `prioritization`)
- `phone_numbers_to_identify` — identify by phone number (requires `prioritization`)

Previously only `aliases_to_identify` was supported. This PR adds support for the email and phone number identifier types, which are used to merge email-only or phone-number-only user profiles into identified users with an `external_id`.

### Changes

- **`lib/braze_ruby/rest/identify_users.rb`** — Accept all three identifier keyword arguments and only include non-empty arrays in the POST payload
- **`spec/braze_ruby/rest/identify_users_spec.rb`** — Add specs for each identifier type, mixed types, and empty defaults
- **`README.md`** — Document email and phone number identification examples
- **`CHANGELOG.md`** — Add entry under Unreleased

### Usage

```ruby
# Identify by email
api.identify_users(
  emails_to_identify: [{
    external_id: 1234,
    email: "user@example.com",
    prioritization: ["unidentified", "most_recently_updated"]
  }]
)

# Identify by phone number
api.identify_users(
  phone_numbers_to_identify: [{
    external_id: 1234,
    phone: "+15555555555",
    prioritization: ["unidentified", "most_recently_updated"]
  }]
)
```